### PR TITLE
Homepage 2026 update and navigation cleanup

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -93,11 +93,9 @@ a.programme-host > div {
   text-decoration: underline dotted;
 }
 
-/* Header: keep nav visible; logo shrinks on medium widths */
+/* Header */
 .main-menu {
-  flex-wrap: wrap;
   overflow: visible;
-  gap: 0.75rem;
 }
 
 .main-menu .logo {

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -84,6 +84,66 @@ a.programme-host > div {
   padding: .1rem .3rem;
 }
 
+.homepage-nav {
+  margin-bottom: 1rem;
+  line-height: 2;
+}
+
+.homepage-nav a:not(.homepage-programme-link) {
+  text-decoration: underline dotted;
+}
+
+/* Header: keep nav visible; logo shrinks on medium widths */
+.main-menu {
+  flex-wrap: wrap;
+  overflow: visible;
+  gap: 0.75rem;
+}
+
+.main-menu .logo {
+  max-width: min(18rem, 55vw);
+}
+
+.main-menu .logo svg {
+  width: 100%;
+  height: auto;
+}
+
+.site-header-nav {
+  flex-shrink: 0;
+}
+
+#menu-wrapper ul li a p {
+  background: var(--critical-highlight);
+  color: rgb(247, 233, 218);
+  padding: 0.2rem 0.4rem;
+}
+
+/* Mission statement callout */
+.mission-statement {
+  background: rgba(128, 20, 50, 0.15);
+  border: 2px solid rgba(247, 233, 218, 0.35);
+  border-left: 5px solid var(--critical-highlight);
+  border-radius: 12px;
+  padding: 1.5rem 2rem;
+  margin: 1.5rem 0 2rem;
+}
+
+.mission-statement h3 {
+  font-family: bold_font;
+  font-size: 1.25rem;
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.mission-statement p:first-of-type {
+  font-family: bold_font;
+  font-size: 1.15rem;
+  line-height: 1.5;
+}
+
 
 nav > a > p,
 div[href^="/programme"],

--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -1,5 +1,12 @@
 [[main]]
-none = "none"
+name = "Call for Contributions"
+url = "/call-for-contributions/"
+weight = 10
+
+[[main]]
+name = "Programme"
+url = "/programme/"
+weight = 20
 
 [[footer]]
 none = "none"

--- a/content/_index.md
+++ b/content/_index.md
@@ -70,11 +70,47 @@ infrastructures for living — with care, agency, and creativity.
 </p>
 -->
 
-## Critical Signals is coming again in 2026
+## What is Critical Signals? {#what-is}
 
-Stay tuned for more details coming soon!
+In our second year as we continue to evolve and discover collectively what this project is and wants to be, we have created an intentions statement so we can be clear with ourselves and our community on what we are working on and how we are working together.
 
-<div style="margin-top: 6rem;"></div>
+<div class="mission-statement" id="mission-statement">
+
+### Our Mission Statement
+
+Critical Signals is a collective endeavour for creative resilience - a gathering place for people who believe communities can shape their own futures.
+
+A bridge between the practical and the visionary: This space brings together artists, researchers, technologists, and communities to ask what changes we could make to our societies, infrastructure, food, and energy systems to ensure we survive disruption and potentially thrive through it.
+
+Together we gather, learn, and act in community: We come together in person, combining arts, tech, politics, and shared meals in public-facing spaces where hopes and fears can be spoken honestly and turned into action. Resources are sought and stewarded to create opportunities for people to connect, learn, wonder, and respond. With community at the centre, this work grows a resilient, self-supporting Aotearoa and contributes meaningfully to possible futures of the wider world.
+
+</div>
+
+## When {#when}
+
+Critical Signals 2026, August 1st-October 31st 2026.
+
+This includes an ongoing relationship with Goethe-Institut New Zealand, alongside whom we have secured some funding for the 2026 programme through the EUNIC fund.
+
+## 2026 Themes {#themes}
+
+Throughout 2026 we'll be focusing on:
+
+- Stuff that Sustains
+- Community Energy
+- Unfolding Futures
+- Next Step Democracy
+- Politics of Space
+
+We are working with an expanding group of people, organisations and communities to bring these topics together in meaningful and practical ways throughout our programme.
+
+<p style="margin-top: 2rem">
+  <a href="/call-for-contributions/" class="homepage-programme-link" style="padding: .5rem;">
+    Call for Contributions
+  </a>
+</p>
+
+<div style="margin-top: 4rem;"></div>
 
 <!-- Newsletter Signup Form -->
 <!-- TODO extract into a partial, make /contact page -->
@@ -119,14 +155,6 @@ Stay tuned for more details coming soon!
     contact@criticalsignals.nz
     </a>
   </p>
-</div>
-<div class="pledgeme-section">
-<h3>Help us to persist and grow!</h3>
-    <form class="pledgeme-form" action="https://pledgeme.co.nz/projects/8444-critical-signals" method="GET" style="display: flex; flex-direction: column; align-items: center; justify-content: center; width: 100%;">
-      <button type="submit" class="pledgeme-form-button" style="background: rgb(128, 20, 50); font-size: 16px; color: rgb(247, 233, 218); font-family: bold_font, Helvetica-Bold, sans-serif; display: flex; width: 100%; max-width: 400px; white-space: normal; height: 42px; align-items: center; justify-content: center; flex-direction: row; padding: 10px 20px; border-radius: 8px; text-align: center; font-style: normal; font-weight: bold; line-height: 20px; border: 3px solid rgb(247, 233, 218); cursor: pointer; transition: all 0.2s ease; text-transform: uppercase; letter-spacing: 0.5px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);">
-        Make a donation
-      </button>
-    </form>
 </div>
 
 <script>

--- a/content/call-for-contributions/index.md
+++ b/content/call-for-contributions/index.md
@@ -6,7 +6,7 @@ See our [mission statement](/#mission-statement) and [2026 themes](/#themes) on 
 
 If this mission and 2026's themes above excites you, please get in touch to offer or create as part of Critical Signals 2026.
 Call for proposals are now open, and we are accepting additions to the core works until the end of May.
-Please send a brief outline (&lt;300words) of your concept and a brief biography of the protagonists to contact@criticalsignals.nz by May 30th.
+Please send a brief outline (&lt;300words) of your concept and a brief biography of the protagonists to [contact@criticalsignals.nz](mailto:contact@criticalsignals.nz) by May 30th.
 
 You can contribute to the programme through any of the following formats:
 
@@ -22,6 +22,12 @@ We will favour evidence-based original material, and if there are repetitions, w
 We are excited by the possibility of working with many of you throughout this year's Critical Signals, August 1st-October 31st 2026.
 
 <p style="margin-top: 2rem">
+  <a href="mailto:contact@criticalsignals.nz?subject=Critical%20Signals%202026%20proposal" class="homepage-programme-link" style="padding: .5rem;">
+    Send your proposal
+  </a>
+</p>
+
+<p style="margin-top: 1rem">
   <a href="/" class="homepage-programme-link" style="padding: .5rem;">
     Back to home
   </a>

--- a/content/call-for-contributions/index.md
+++ b/content/call-for-contributions/index.md
@@ -1,0 +1,28 @@
+---
+title: Call for Contributions
+---
+
+See our [mission statement](/#mission-statement) and [2026 themes](/#themes) on the home page.
+
+If this mission and 2026's themes above excites you, please get in touch to offer or create as part of Critical Signals 2026.
+Call for proposals are now open, and we are accepting additions to the core works until the end of May.
+Please send a brief outline (&lt;300words) of your concept and a brief biography of the protagonists to contact@criticalsignals.nz by May 30th.
+
+You can contribute to the programme through any of the following formats:
+
+- Workshops
+- Talks
+- Skills Sharing
+- Community Connections (regular or one off)
+- Practical Making Events
+- Artworks + Experiences
+
+We will favour evidence-based original material, and if there are repetitions, workshops that engage in more ways than with words. We will endeavour to respond by June 20th.
+
+We are excited by the possibility of working with many of you throughout this year's Critical Signals, August 1st-October 31st 2026.
+
+<p style="margin-top: 2rem">
+  <a href="/" class="homepage-programme-link" style="padding: .5rem;">
+    Back to home
+  </a>
+</p>

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -1,9 +1,9 @@
 <div style="padding-left:0;padding-right:0;padding-top:2px;padding-bottom:3px"
-  class="main-menu flex items-center justify-between px-4 py-6 sm:px-6 gap-x-3">
+  class="main-menu flex items-center justify-between px-4 py-6 sm:px-6 gap-x-3 w-full">
   {{ if .Site.Params.Logo }}
     {{ $logo := resources.Get .Site.Params.Logo }}
     {{ if $logo }}
-      <div>
+      <div class="shrink-0">
         <a href="{{ "" | relLangURL }}" class="flex">
           <span class="sr-only">{{ .Site.Title | markdownify }}</span>
 
@@ -21,64 +21,70 @@
     {{ end }}
   {{- end }}
 
-  <div class="flex flex-1 items-center justify-end gap-x-5 h-12 shrink-0">
+  <nav class="site-header-nav hidden lg:flex items-center gap-x-5 ml-auto h-12 shrink-0">
+    {{ if .Site.Menus.main }}
+      {{ range .Site.Menus.main }}
+        {{ partial "header/header-option.html" . }}
+      {{ end }}
+    {{ end }}
+
     {{ partial "translations.html" . }}
 
     {{ if .Site.Params.enableSearch | default false }}
-      <button id="search-button-mobile" aria-label="Search" class="text-base hover:text-primary-600 dark:hover:text-primary-400"
+      <button id="search-button" aria-label="Search" class="text-base hover:text-primary-600 dark:hover:text-primary-400"
         title="{{ i18n " search.open_button_title" }}">
         {{ partial "icon.html" "search" }}
       </button>
     {{ end }}
+  </nav>
 
-    <div class="-my-2 shrink-0">
-      <label id="menu-button" class="block">
-        {{ if .Site.Menus.main }}
-          <div class="cursor-pointer hover:text-primary-600 dark:hover:text-primary-400">
-            {{ partial "icon.html" "bars" }}
-          </div>
-          <div id="menu-wrapper" style="padding-top:5px;"
-            class="fixed inset-0 z-30 invisible w-screen h-screen m-0 overflow-auto transition-opacity opacity-0 cursor-default bg-neutral-100/50 backdrop-blur-sm dark:bg-neutral-900/50">
+  <div class="lg:hidden shrink-0 ml-auto">
+    <label id="menu-button" class="block">
+      {{ if .Site.Menus.main }}
+        <div class="cursor-pointer hover:text-primary-600 dark:hover:text-primary-400">
+          {{ partial "icon.html" "bars" }}
+        </div>
+        <div id="menu-wrapper" style="padding-top:5px;"
+          class="fixed inset-0 z-30 invisible w-screen h-screen m-0 overflow-auto transition-opacity opacity-0 cursor-default bg-neutral-100/50 backdrop-blur-sm dark:bg-neutral-900/50">
 
-            <ul class="flex space-y-2 mt-3 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none ltr:text-right rtl:text-left max-w-7xl">
-              <li id="menu-close-button">
-                <span
-                  class="cursor-pointer inline-block align-text-bottom hover:text-primary-600 dark:hover:text-primary-400">{{
-                  partial
-                  "icon.html"
-                  "xmark" }}</span>
-              </li>
+          <ul class="flex space-y-2 mt-3 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none ltr:text-right rtl:text-left max-w-7xl">
+            <li id="menu-close-button">
+              <span
+                class="cursor-pointer inline-block align-text-bottom hover:text-primary-600 dark:hover:text-primary-400">{{
+                partial
+                "icon.html"
+                "xmark" }}</span>
+            </li>
 
-              {{ range .Site.Menus.main }}
-                {{ partial "header/header-mobile-option.html" . }}
+            {{ range .Site.Menus.main }}
+              {{ partial "header/header-mobile-option.html" . }}
+            {{ end }}
+          </ul>
+
+          {{ if .Site.Menus.subnavigation }}
+            <hr>
+            <ul class="flex mt-4 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none ltr:text-right rtl:text-left max-w-7xl">
+              {{ range .Site.Menus.subnavigation }}
+                <li class="mb-1">
+                  <a href="{{ .URL }}" {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:"
+                    ) }} target="_blank" {{ end }} class="flex items-center">
+                    {{ if .Pre }}
+                    <span {{ if and .Pre .Name}} class="mr-3" {{ end }}>
+                      {{ partial "icon.html" .Pre }}
+                    </span>
+                    {{ end }}
+                    <p class="text-sm font-sm text-gray-500 hover:text-gray-900" title="{{ .Title }}">
+                      {{ .Name | markdownify }}
+                    </p>
+                  </a>
+                </li>
               {{ end }}
             </ul>
+          {{ end }}
 
-            {{ if .Site.Menus.subnavigation }}
-              <hr>
-              <ul class="flex mt-4 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none ltr:text-right rtl:text-left max-w-7xl">
-                {{ range .Site.Menus.subnavigation }}
-                  <li class="mb-1">
-                    <a href="{{ .URL }}" {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:"
-                      ) }} target="_blank" {{ end }} class="flex items-center">
-                      {{ if .Pre }}
-                      <span {{ if and .Pre .Name}} class="mr-3" {{ end }}>
-                        {{ partial "icon.html" .Pre }}
-                      </span>
-                      {{ end }}
-                      <p class="text-sm font-sm text-gray-500 hover:text-gray-900" title="{{ .Title }}">
-                        {{ .Name | markdownify }}
-                      </p>
-                    </a>
-                  </li>
-                {{ end }}
-              </ul>
-            {{ end }}
-
-          </div>
-        {{ end }}
-      </label>
-    </div>
+        </div>
+      {{ end }}
+    </label>
   </div>
 </div>
 

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -1,5 +1,5 @@
 <div style="padding-left:0;padding-right:0;padding-top:2px;padding-bottom:3px"
-  class="main-menu flex items-center justify-between px-4 py-6 sm:px-6 md:justify-start gap-x-3">
+  class="main-menu flex items-center justify-between px-4 py-6 sm:px-6 gap-x-3">
   {{ if .Site.Params.Logo }}
     {{ $logo := resources.Get .Site.Params.Logo }}
     {{ if $logo }}
@@ -21,146 +21,66 @@
     {{ end }}
   {{- end }}
 
-  <div class="flex flex-1 items-center justify-between">
-    <nav class="flex space-x-3">
-      {{ if not .Site.Params.disableTextInHeader | default true }}
-        <a href="{{ "" | relLangURL }}" class="text-base font-medium text-gray-500 hover:text-gray-900">
-          {{ .Site.Title | markdownify }}
-        </a>
-      {{ end }}
-    </nav>
+  <div class="flex flex-1 items-center justify-end gap-x-5 h-12 shrink-0">
+    {{ partial "translations.html" . }}
 
-    <nav class="hidden md:flex items-center gap-x-5 md:ml-12 h-12">
-      {{ if .Site.Menus.main }}
-        {{ range .Site.Menus.main }}
-          {{ partial "header/header-option.html" . }}
-        {{ end }}
-      {{ end }}
+    {{ if .Site.Params.enableSearch | default false }}
+      <button id="search-button-mobile" aria-label="Search" class="text-base hover:text-primary-600 dark:hover:text-primary-400"
+        title="{{ i18n " search.open_button_title" }}">
+        {{ partial "icon.html" "search" }}
+      </button>
+    {{ end }}
 
-      {{ partial "translations.html" . }}
+    <div class="-my-2 shrink-0">
+      <label id="menu-button" class="block">
+        {{ if .Site.Menus.main }}
+          <div class="cursor-pointer hover:text-primary-600 dark:hover:text-primary-400">
+            {{ partial "icon.html" "bars" }}
+          </div>
+          <div id="menu-wrapper" style="padding-top:5px;"
+            class="fixed inset-0 z-30 invisible w-screen h-screen m-0 overflow-auto transition-opacity opacity-0 cursor-default bg-neutral-100/50 backdrop-blur-sm dark:bg-neutral-900/50">
 
-      {{ if .Site.Params.enableSearch | default false }}
-        <button id="search-button" aria-label="Search" class="text-base hover:text-primary-600 dark:hover:text-primary-400"
-          title="{{ i18n " search.open_button_title" }}">
-          {{ partial "icon.html" "search" }}
-        </button>
-      {{ end }}
+            <ul class="flex space-y-2 mt-3 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none ltr:text-right rtl:text-left max-w-7xl">
+              <li id="menu-close-button">
+                <span
+                  class="cursor-pointer inline-block align-text-bottom hover:text-primary-600 dark:hover:text-primary-400">{{
+                  partial
+                  "icon.html"
+                  "xmark" }}</span>
+              </li>
 
-
-      {{/* Appearance switch */}}
-      <!-- {{ if .Site.Params.footer.showAppearanceSwitcher | default false }} -->
-      <!--   <div -->
-      <!--     class="{{ if .Site.Params.footer.showScrollToTop | default true -}} {{- end }} flex items-center"> -->
-      <!--     <button id="appearance-switcher" aria-label="Dark mode switcher" type="button" class="text-base hover:text-primary-600 dark:hover:text-primary-400"> -->
-      <!--       <div class="flex items-center justify-center dark:hidden"> -->
-      <!--         {{ partial "icon.html" "moon" }} -->
-      <!--       </div> -->
-      <!--       <div class="items-center justify-center hidden dark:flex"> -->
-      <!--         {{ partial "icon.html" "sun" }} -->
-      <!--       </div> -->
-      <!--     </button> -->
-      <!--   </div> -->
-      <!-- {{ end }} -->
-    </nav>
-
-    <div class="flex md:hidden items-center gap-x-5 md:ml-12 h-12">
-
-      <span></span>
-
-      {{ partial "translations.html" . }}
-
-      {{ if .Site.Params.enableSearch | default false }}
-        <button id="search-button-mobile" aria-label="Search" class="text-base hover:text-primary-600 dark:hover:text-primary-400"
-          title="{{ i18n " search.open_button_title" }}">
-          {{ partial "icon.html" "search" }}
-        </button>
-      {{ end }}
-
-      {{/* Appearance switch */}}
-      <!-- {{ if .Site.Params.footer.showAppearanceSwitcher | default false }} -->
-      <!--   <button id="appearance-switcher-mobile" aria-label="Dark mode switcher" type="button" class="text-base hover:text-primary-600 dark:hover:text-primary-400 ltr:mr-1 rtl:ml-1"> -->
-      <!--     <div class="flex items-center justify-center dark:hidden"> -->
-      <!--       {{ partial "icon.html" "moon" }} -->
-      <!--     </div> -->
-      <!--     <div class="items-center justify-center hidden dark:flex"> -->
-      <!--       {{ partial "icon.html" "sun" }} -->
-      <!--     </div> -->
-      <!--   </button> -->
-      <!-- {{ end }} -->
-
-    </div>
-  </div>
-
-  <div class="-my-2 md:hidden">
-    <label id="menu-button" class="block">
-      {{ if .Site.Menus.main }}
-        <div class="cursor-pointer hover:text-primary-600 dark:hover:text-primary-400">
-          {{ partial "icon.html" "bars" }}
-        </div>
-        <div id="menu-wrapper" style="padding-top:5px;"
-          class="fixed inset-0 z-30 invisible w-screen h-screen m-0 overflow-auto transition-opacity opacity-0 cursor-default bg-neutral-100/50 backdrop-blur-sm dark:bg-neutral-900/50">
-
-          <ul class="flex space-y-2 mt-3 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none ltr:text-right rtl:text-left max-w-7xl">
-            <li id="menu-close-button">
-              <span
-                class="cursor-pointer inline-block align-text-bottom hover:text-primary-600 dark:hover:text-primary-400">{{
-                partial
-                "icon.html"
-                "xmark" }}</span>
-            </li>
-
-            {{ range .Site.Menus.main }}
-              {{ partial "header/header-mobile-option.html" . }}
-            {{ end }}
-          </ul>
-
-          {{ if .Site.Menus.subnavigation }}
-            <hr>
-            <ul class="flex mt-4 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none ltr:text-right rtl:text-left max-w-7xl">
-              {{ range .Site.Menus.subnavigation }}
-                <li class="mb-1">
-                  <a href="{{ .URL }}" {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:"
-                    ) }} target="_blank" {{ end }} class="flex items-center">
-                    {{ if .Pre }}
-                    <span {{ if and .Pre .Name}} class="mr-3" {{ end }}>
-                      {{ partial "icon.html" .Pre }}
-                    </span>
-                    {{ end }}
-                    <p class="text-sm font-sm text-gray-500 hover:text-gray-900" title="{{ .Title }}">
-                      {{ .Name | markdownify }}
-                    </p>
-                  </a>
-                </li>
+              {{ range .Site.Menus.main }}
+                {{ partial "header/header-mobile-option.html" . }}
               {{ end }}
             </ul>
-          {{ end }}
 
+            {{ if .Site.Menus.subnavigation }}
+              <hr>
+              <ul class="flex mt-4 flex-col items-end w-full px-6 py-6 mx-auto overflow-visible list-none ltr:text-right rtl:text-left max-w-7xl">
+                {{ range .Site.Menus.subnavigation }}
+                  <li class="mb-1">
+                    <a href="{{ .URL }}" {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:"
+                      ) }} target="_blank" {{ end }} class="flex items-center">
+                      {{ if .Pre }}
+                      <span {{ if and .Pre .Name}} class="mr-3" {{ end }}>
+                        {{ partial "icon.html" .Pre }}
+                      </span>
+                      {{ end }}
+                      <p class="text-sm font-sm text-gray-500 hover:text-gray-900" title="{{ .Title }}">
+                        {{ .Name | markdownify }}
+                      </p>
+                    </a>
+                  </li>
+                {{ end }}
+              </ul>
+            {{ end }}
+
+          </div>
         {{ end }}
-      </div>
-    </label>
-  </div>
-</div>
-
-{{ if .Site.Menus.subnavigation }}
-  <div class="main-menu flex pb-3 flex-col items-end justify-between md:justify-start space-x-3" {{ if .Site.Params.Logo
-    }} style="margin-top:-15px" {{ end }}>
-    <div class="hidden md:flex items-center space-x-5">
-      {{ range .Site.Menus.subnavigation }}
-        <a href="{{ .URL }}" {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:" ) }}
-          target="_blank" {{ end }} class="flex items-center">
-          {{ if .Pre }}
-          <span {{ if and .Pre .Name}} class="mr-1" {{ end }}>
-            {{ partial "icon.html" .Pre }}
-          </span>
-          {{ end }}
-          <p class="text-xs font-light text-gray-500 hover:text-gray-900" title="{{ .Title }}">
-            {{ .Name | markdownify }}
-          </p>
-        </a>
-      {{ end }}
+      </label>
     </div>
   </div>
-{{ end }}
+</div>
 
 {{ if .Site.Params.highlightCurrentMenuArea }}
   <script>

--- a/layouts/partials/header/header-mobile-option-simple.html
+++ b/layouts/partials/header/header-mobile-option-simple.html
@@ -1,0 +1,19 @@
+<li class="mt-1">
+  <a
+    href="{{ .URL }}"
+    {{ if or (strings.HasPrefix .URL "http:" ) (strings.HasPrefix .URL "https:"
+      )
+    }}
+      target="_blank"
+    {{ end }}
+    class="flex items-center text-gray-500 hover:text-primary-600 dark:hover:text-primary-400">
+    {{ if .Pre }}
+      <div {{ if and .Pre .Name }}class="mr-2"{{ end }}>
+        {{ partial "icon.html" .Pre }}
+      </div>
+    {{ end }}
+    <p class="text-base font-medium" title="{{ .Title }}">
+      {{ .Name | markdownify }}
+    </p>
+  </a>
+</li>

--- a/layouts/partials/home/custom.html
+++ b/layouts/partials/home/custom.html
@@ -8,6 +8,8 @@
 {{ $imageBreakpointLarge := "750px" }}
 {{ partial "home/hero-image-rendition.html" . }}
 
+{{ partial "home/nav.html" . }}
+
 <!-- an approximation of the homepage hero content for people using screen readers -->
 <div class="sr-only">
   <h1>Critical Signals</h1>
@@ -207,6 +209,13 @@ initializeHero()
   .main-menu {
     padding-inline: var(--page-gutter) !important;
     max-width: var(--container-7xl);
+  }
+
+  .homepage-nav {
+    max-width: var(--content-max-width-plus-gutters);
+    margin-inline: auto;
+    padding-inline: var(--page-gutter);
+    margin-bottom: 1rem;
   }
 }
 

--- a/layouts/partials/home/nav.html
+++ b/layouts/partials/home/nav.html
@@ -1,0 +1,6 @@
+<p class="homepage-nav">
+  <a href="#what-is">What is Critical Signals?</a> ·
+  <a href="#when">When</a> ·
+  <a href="#themes">Themes</a> ·
+  <a href="/call-for-contributions/" class="homepage-programme-link">Call for Contributions</a>
+</p>


### PR DESCRIPTION
## Summary

- Restructured homepage with What is / When / Themes sections and highlighted mission statement
- Added `/call-for-contributions/` page with full call text, formats, and Send your proposal mailto button
- Added homepage jump links above the hero
- Header nav: desktop links on wide screens; hamburger on mobile, right-aligned
- Removed old PledgeMe donation section from homepage

## Test plan

- [ ] Run `hugo serve --buildFuture` and review homepage layout
- [ ] Confirm desktop nav and mobile hamburger behave correctly
- [ ] Check Call for Contributions page — email link and Send your proposal button